### PR TITLE
Example: Adding manifests to default windows and catalog

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,36 @@
 import Mirador from 'mirador/dist/es/src/index';
 import examplePlugin from './plugins/example_plugin';
 
+// Example: Some IIIF manifests related to cats! 🐱
+// TASK 1: Show the Washington State University manifest in the main viewer
+// TASK 2: Add your own manifest to the catalog (Try https://researchworks.oclc.org/iiif-explorer/ for more cat photos)
+// BONUS: Add the missing provider info for "[A leveret adopted by a cat]"
 const config = {
-  id: 'mirador-viewer',
-  windows: [
-    {
-      manifestId: 'https://purl.stanford.edu/fr426cg9537/iiif/manifest',
-    }
-  ],
+    id: 'mirador-viewer',
+    windows: [{ // These manifests will load in the viewer
+            manifestId: 'https://damsssl.llgc.org.uk/iiif/2.0/1556378/manifest.json',
+        },
+        {
+            manifestId: 'https://damsssl.llgc.org.uk/iiif/2.0/1487439/manifest.json',
+            canvasIndex: 1,
+        }
+    ],
+    catalog: [{ // These manifests are available in the catalog. 
+            manifestId: 'https://damsssl.llgc.org.uk/iiif/2.0/1556378/manifest.json',
+            provider: 'The National Library of Wales',
+        },
+        {
+            manifestId: 'https://damsssl.llgc.org.uk/iiif/2.0/1487439/manifest.json',
+        },
+        {
+            manifestId: 'https://cdm16866.contentdm.oclc.org/iiif/info/cchm_photo/5342/manifest.json',
+            provider: 'Washington State University',
+        },
+        { // Secret cat on the 76th page
+            manifestId: 'https://iiif.bodleian.ox.ac.uk/iiif/manifest/faeff7fb-f8a7-44b5-95ed-cff9a9ffd198.json',
+            provider: 'Bodleian Libraries, University of Oxford',
+        }
+    ]
 };
 
 const plugins = [];


### PR DESCRIPTION
[Demo: A simple example for adding manifests to the default windows and the catalog 🐱](https://deploy-preview-6--mirador-workshop.netlify.app/)

TASK 1: Show the Washington State University manifest in the main viewer
TASK 2: Add your own manifest to the catalog (Try https://researchworks.oclc.org/iiif-explorer/ for more IIIF cat photos)
BONUS: Add the missing provider info for "[A leveret adopted by a cat]" (it currently says "Added by URL").

![Screen Shot 2020-11-30 at 8 01 39 PM](https://user-images.githubusercontent.com/5402927/100695807-e6552880-3346-11eb-9736-dd0937a1353a.png)

![Screen Shot 2020-11-30 at 7 53 25 PM](https://user-images.githubusercontent.com/5402927/100695639-7cd51a00-3346-11eb-8185-9bbd94c952af.png)
 